### PR TITLE
SV/Add Makefile and additional features to Hap-IBD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ hap-ibd.jar: hapIbdMain
 	jar cfe hap-ibd.jar hapibd/HapIbdMain -C src/ ./
 
 clean :
-	rm -f src/*/*.class
+	rm -f src/*/*.class hap-ibd.jar

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+sources = $(wildcard src/*/*.java)
+classes = $(sources:.java=.class)
+
+all: hapIbdMain hap-ibd.jar
+
+hapIbdMain: $(classes)
+
+%.class : %.java
+	javac -cp src/ $<
+
+hap-ibd.jar: hapIbdMain
+	jar cfe hap-ibd.jar hapibd/HapIbdMain -C src/ ./
+
+clean :
+	rm -f src/*/*.class

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ use. The default **nthreads** parameter is the number of CPU cores.
 * **excludesamples=[file]** where [file] is a text file containing samples
 (one sample per line) to be excluded from the analysis.
 
+* **includesamples=[file]** where [file] is a text file containing samples
+(one sample per line) to be included from the analysis. Cannot be used with
+**excludedsamples**.
+
 
 ## Output files
 The **hap-ibd** program produces three output files: a **log** file, an
@@ -163,3 +167,4 @@ You may obtain a copy of the License from http://www.apache.org/licenses/LICENSE
 
 * Add [Makefile](Makefile).
 * Allow indel variants encoded as `I` and `D` in the input VCF file.
+* Add option **includesamples**.

--- a/README.md
+++ b/README.md
@@ -159,3 +159,6 @@ files represents one IBD or HBD segment and contains 8 tab-delimited fields:
 The **hap-ibd** program is licensed under the Apache License, Version 2.0 (the License).
 You may obtain a copy of the License from http://www.apache.org/licenses/LICENSE-2.0
 
+## Changelog
+
+* Add [Makefile](Makefile).

--- a/README.md
+++ b/README.md
@@ -119,11 +119,12 @@ Increasing the **min-markers** parameter can reduce inflation in
 the number of output IBD segments in regions with sparse marker coverage.
 See the **min-seed** and **min-extend** parameters for more information.
 
-* **min-mac=[integer ≥ 1]** specifies the minimum number of copies of the minor
+* **min-mac=[integer ≥ 0]** specifies the minimum number of copies of the minor
 allele. If a marker has fewer than the minimum number of minor allele carriers,
 the marker will be excluded from the analysis (**default: min-mac=2**).
 For multi-allelic markers, the minor allele count is the number of copies of
-the allele with the second-largest allele frequency.
+the allele with the second-largest allele frequency. If **min-mac=0** no
+markers will be excluded.
 
 * **nthreads=[integer ≥ 1]** specifies the number of computational threads to
 use. The default **nthreads** parameter is the number of CPU cores.
@@ -168,3 +169,4 @@ You may obtain a copy of the License from http://www.apache.org/licenses/LICENSE
 * Add [Makefile](Makefile).
 * Allow indel variants encoded as `I` and `D` in the input VCF file.
 * Add option **includesamples**.
+* Allow min-mac to be set to 0 to disable the minor allele count filter.

--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ You may obtain a copy of the License from http://www.apache.org/licenses/LICENSE
 ## Changelog
 
 * Add [Makefile](Makefile).
+* Allow indel variants encoded as `I` and `D` in the input VCF file.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ with the commands:
     jar cfe hap-ibd.jar hapibd/HapIbdMain -C hap-ibd/src/ ./
     jar -i hap-ibd.jar
 
+These commands are encapsulated in the [Makefile](Makefile).
+
 ## Running hap-ibd
 
 The **hap-ibd** program requires Java version 1.8 (or a later version). Use of an

--- a/src/hapibd/HapIbdMain.java
+++ b/src/hapibd/HapIbdMain.java
@@ -98,7 +98,8 @@ public class HapIbdMain {
         File file = new File(par.out() + outSuffix);
         if (file.equals(par.gt())
                 || file.equals(par.map())
-                || file.equals(par.excludesamples())) {
+                || file.equals(par.excludesamples())
+                || file.equals(par.includesamples())) {
             String s = "ERROR: Output file equals input file: " + file;
             Utilities.exit(HapIbdPar.usage() + s);
         }
@@ -149,6 +150,11 @@ public class HapIbdMain {
             sb.append(Const.nl);
             sb.append("  excludesamples   :  ");
             sb.append(par.excludesamples());
+        }
+        if (par.includesamples()!=null) {
+            sb.append(Const.nl);
+            sb.append("  includesamples   :  ");
+            sb.append(par.includesamples());
         }
         sb.append(Const.nl);
         sb.append("  min-seed         :  ");

--- a/src/hapibd/HapIbdPar.java
+++ b/src/hapibd/HapIbdPar.java
@@ -88,7 +88,7 @@ public final class HapIbdPar {
                 argsMap, false, null, null));
 
         // algorithm parameters
-        min_mac = Validate.intArg("min-mac", argsMap, false, DEF_MIN_MAC, 1, IMAX);
+        min_mac = Validate.intArg("min-mac", argsMap, false, DEF_MIN_MAC, 0, IMAX);
         min_seed = Validate.floatArg("min-seed", argsMap, false, DEF_MIN_SEED, FMIN, FMAX);
         max_gap = Validate.intArg("max-gap", argsMap, false, DEF_MAX_GAP, -1, IMAX);
         float minMinExtend = Math.min(min_seed, DEF_MIN_EXTEND);

--- a/src/hapibd/HapIbdPar.java
+++ b/src/hapibd/HapIbdPar.java
@@ -40,6 +40,7 @@ public final class HapIbdPar {
     private final File map;
     private final String out;
     private final File excludesamples;
+    private final File includesamples;
 
     // algorithm parameters
     private final int min_mac;
@@ -83,6 +84,8 @@ public final class HapIbdPar {
         out = Validate.stringArg("out", argsMap, true, null, null);
         excludesamples = Validate.getFile(Validate.stringArg("excludesamples",
                 argsMap, false, null, null));
+        includesamples = Validate.getFile(Validate.stringArg("includesamples",
+                argsMap, false, null, null));
 
         // algorithm parameters
         min_mac = Validate.intArg("min-mac", argsMap, false, DEF_MIN_MAC, 1, IMAX);
@@ -118,7 +121,8 @@ public final class HapIbdPar {
                 + "  gt=<VCF file with GT field>                         (required)" + nl
                 + "  map=<PLINK map file with cM units>                  (required)" + nl
                 + "  out=<output file prefix>                            (required)" + nl
-                + "  excludesamples=<excluded samples file>              (optional)" + nl + nl
+                + "  excludesamples=<excluded samples file>              (optional)" + nl
+                + "  includesamples=<included samples file>              (optional)" + nl + nl
 
                 + "Algorithm Parameters: " + nl
                 + "  min-seed=<min cM length of seed segment>            (default: " + DEF_MIN_SEED + ")" + nl
@@ -173,6 +177,17 @@ public final class HapIbdPar {
      */
     public File excludesamples() {
         return excludesamples;
+    }
+
+    /**
+     * Returns the includesamples parameter or {@code null}
+     * if no includesamples parameter was specified.
+     *
+     * @return the includesamples parameter or {@code null}
+     * if no includesamples parameter was specified
+     */
+    public File includesamples() {
+        return includesamples;
     }
 
     // algorithm parameters

--- a/src/hapibd/PbwtIbdDriver.java
+++ b/src/hapibd/PbwtIbdDriver.java
@@ -115,7 +115,7 @@ public final class PbwtIbdDriver {
     }
 
     private static SampleFileIt<RefGTRec> refIt(HapIbdPar par) {
-        Filter<String> sFilter = FilterUtil.sampleFilter(par.excludesamples());
+        Filter<String> sFilter = FilterUtil.sampleFilter(par.excludesamples(), par.includesamples());
         Filter<Marker> mFilter = Filter.acceptAllFilter();
         FileIt<String> it0 = InputIt.fromGzipFile(par.gt());
         return RefIt.create(it0, sFilter, mFilter);

--- a/src/vcf/BasicMarker.java
+++ b/src/vcf/BasicMarker.java
@@ -151,9 +151,9 @@ public class BasicMarker implements Marker {
         }
         for  (int j=0, n=ref.length(); j<n; ++j) {
             char c = Character.toUpperCase(ref.charAt(j));
-            if ((c=='A' || c=='C' || c=='G' || c=='T' || c=='N')==false) {
+            if ((c=='A' || c=='C' || c=='G' || c=='T' || c=='I' || c=='D' || c=='N')==false) {
                 String s = "ERROR: REF field is not a sequence"
-                        + " of A, C, T, G, or N characters at "
+                        + " of A, C, T, G, I, D, or N characters at "
                         + coordinate(chrom, pos) + " [" + ref + "]" ;
                 Utilities.exit(s);
             }
@@ -179,7 +179,7 @@ public class BasicMarker implements Marker {
         else {
             for (int j=0; j<n; ++j) {
                 char c = Character.toUpperCase(alt.charAt(j));
-                if ((c=='A' || c=='C' || c=='G' || c=='T' || c=='N')==false) {
+                if ((c=='A' || c=='C' || c=='G' || c=='T' || c=='I' || c=='D' || c=='N')==false) {
                     String s = "ERROR: invalid ALT allele at "
                             + coordinate(chrom, pos) + " [" + alt + "]";
                     Utilities.exit(s);
@@ -385,7 +385,7 @@ public class BasicMarker implements Marker {
      * @return the string allele obtained by changing the specified allele
      * to the opposite chromosome strand
      * @throws IllegalArgumentException if any character in the specified
-     * string is not 'A', 'C', 'G', 'T', 'N', or '*'.
+     * string is not 'A', 'C', 'G', 'T', 'I', 'D', 'N', or '*'.
      * @throws NullPointerException if {@code allele == null}
      */
     public static String flipStrand(String allele) {
@@ -403,6 +403,8 @@ public class BasicMarker implements Marker {
             case 'G' : return 'C';
             case 'T' : return 'A';
             case 'N' : return 'N';
+            case 'I' : return 'I';
+            case 'D' : return 'D';
             case '*' : return '*';
             default: throw new IllegalArgumentException(String.valueOf(c));
         }

--- a/src/vcf/FilterUtil.java
+++ b/src/vcf/FilterUtil.java
@@ -81,14 +81,19 @@ public final class FilterUtil {
      * file contains two non-white-space characters separated by one or
      * more white-space characters
      */
-    public static Filter<String> sampleFilter(File excludeSamplesFile) {
-        if (excludeSamplesFile==null) {
-            return Filter.acceptAllFilter();
+    public static Filter<String> sampleFilter(File excludeSamplesFile, File includeSamplesFile) {
+        if (excludeSamplesFile!=null && includeSamplesFile!=null) {
+            throw new IllegalArgumentException("excludesamples and includesamples cannot be used together.");
         }
-        else {
+        else if (excludeSamplesFile!=null) {
            Set<String> exclude = Utilities.idSet(excludeSamplesFile);
            return Filter.excludeFilter(exclude);
         }
+        else if (includeSamplesFile!=null) {
+           Set<String> include = Utilities.idSet(includeSamplesFile);
+           return Filter.includeFilter(include);
+        }
+        return Filter.acceptAllFilter();
     }
 
     /**


### PR DESCRIPTION
This PR adds a Makefile and basic additional features to Hap-IBD. The Makefile makes it easier to rebuild the jar from source. I removed the jar indexing step because it is deprecated.

Additional Features:
* Accept indels encoded as `I` and `D` as markers for IBD detection. Without this feature, Hap-IBD will throw an exception if it encounters these variants.
* Add an `includesamples` option similar to the `excludesamples` option already provided in Hap-IBD but works by excluding all samples that are NOT included in the `includesamples` file.
* Allow the minor allele count filter to be disabled by setting `min-mac=0`. This change allows for the same markers to be used for independent runs with different sets of individuals.