### PR TITLE
Split output into one file per new dog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ use. The default **nthreads** parameter is the number of CPU cores.
 * **min-new-proxykey=[integer ≥ 0]** specifies the proxy key value above
 which (inclusive) to treat proxy keys as "new" dogs in a comparison set.
 If specified, output will only be written for new dogs, and only for
-new dog x old dog matches.
+new dog x old dog matches, and no homozygosity will be output.
 To produce output for all dogs x all dogs (eg for all new dogs vs all 
-new dogs, if the input has been filtered to just new dogs) then don't
-provide this parameter (or set it to zero).
+new dogs, if the input has been filtered to just new dogs), including
+homozygosity, don't provide this parameter (or set it to zero).
 
 ## Output files
 The **hap-ibd** program produces three output files: a **log** file, an

--- a/README.md
+++ b/README.md
@@ -134,8 +134,15 @@ use. The default **nthreads** parameter is the number of CPU cores.
 
 * **includesamples=[file]** where [file] is a text file containing samples
 (one sample per line) to be included from the analysis. Cannot be used with
-**excludedsamples**.
+**excludedsamples**. NOTE this is slower than filtering with VCF instead.
 
+* **min-new-proxykey=[integer ≥ 0]** specifies the proxy key value above
+which (inclusive) to treat proxy keys as "new" dogs in a comparison set.
+If specified, output will only be written for new dogs, and only for
+new dog x old dog matches.
+To produce output for all dogs x all dogs (eg for all new dogs vs all 
+new dogs, if the input has been filtered to just new dogs) then don't
+provide this parameter (or set it to zero).
 
 ## Output files
 The **hap-ibd** program produces three output files: a **log** file, an

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ To produce output for all dogs x all dogs (eg for all new dogs vs all
 new dogs, if the input has been filtered to just new dogs), including
 homozygosity, don't provide this parameter (or set it to zero).
 
+* **split=[boolean]** specifies whether to write output to individual files per sample.
+If true, each sample's IBD and HBD segments will be written to separate files
+with names like `{out}/proxy_key/{split-filename}.ibd` and
+`{out}/proxy_key/{split-filename}.hbd`.
+`out` example: "/tmp/blah". `split-filename` example: "0000_chr1".
+If false (default), all segments will be written to single `{output_prefix}.ibd`
+and `{output_prefix}.hbd` files.
+
 ## Output files
 The **hap-ibd** program produces three output files: a **log** file, an
  **ibd** file, and an **hbd** file.

--- a/src/hapibd/HapIbdMain.java
+++ b/src/hapibd/HapIbdMain.java
@@ -84,14 +84,25 @@ public class HapIbdMain {
 
     private static void checkOutputPrefix(HapIbdPar par) {
         File outPrefix = new File(par.out());
-        if (outPrefix.isDirectory()) {
-            String s = "ERROR: \"out\" parameter cannot be a directory: \""
-                    + par.out() + "\"";
-            Utilities.exit(HapIbdPar.usage() + s);
+
+        if (par.split()) {
+            // When split is enabled, we don't need to check for .hbd and .ibd files
+            // since they will be created per sample
+            checkOutputFilename(par, ".log");
+            if (par.splitFilename() == null) {
+                String s = "ERROR: split-filename parameter is required when split is enabled";
+                Utilities.exit(HapIbdPar.usage() + s);
+            }
+        } else {
+            if (outPrefix.isDirectory()) {
+                String s = "ERROR: \"out\" parameter cannot be a directory: \""
+                        + par.out() + "\"";
+                Utilities.exit(HapIbdPar.usage() + s);
+            }
+            checkOutputFilename(par, ".hbd");
+            checkOutputFilename(par, ".ibd");
+            checkOutputFilename(par, ".log");
         }
-        checkOutputFilename(par, ".hbd");
-        checkOutputFilename(par, ".ibd");
-        checkOutputFilename(par, ".log");
     }
 
     private static void checkOutputFilename(HapIbdPar par, String outSuffix) {

--- a/src/hapibd/HapIbdPar.java
+++ b/src/hapibd/HapIbdPar.java
@@ -17,7 +17,6 @@
  */
 package hapibd;
 
-import beagleutil.ChromInterval;
 import blbutil.Const;
 import blbutil.Validate;
 import java.io.File;
@@ -39,6 +38,7 @@ public final class HapIbdPar {
     private final File gt;
     private final File map;
     private final String out;
+    private final String splitFilename;
     private final File excludesamples;
     private final File includesamples;
 
@@ -51,6 +51,7 @@ public final class HapIbdPar {
     private final int min_markers;
     private final int nthreads;
     private final int min_new_proxykey;
+    private final boolean split;
     private static final int DEF_MIN_MAC = 2;
     private static final float DEF_MIN_SEED = 2.0f;
     private static final float DEF_MIN_EXTEND = 1.0f;
@@ -59,6 +60,7 @@ public final class HapIbdPar {
     private static final int DEF_MIN_MARKERS = 100;
     private static final int DEF_NTHREADS = Runtime.getRuntime().availableProcessors();
     private static final int DEF_MIN_NEW_PROXYKEY = 0;
+    private static final boolean DEF_SPLIT = false;
     /**
      * Constructs an {@code HapIbdPar} object that represents the
      * command line arguments for the HapIBD program.  See the
@@ -82,6 +84,7 @@ public final class HapIbdPar {
                 null));
         map = Validate.getFile(Validate.stringArg("map", argsMap, true, null, null));
         out = Validate.stringArg("out", argsMap, true, null, null);
+        splitFilename = Validate.stringArg("split-filename", argsMap, false, null, null);
         excludesamples = Validate.getFile(Validate.stringArg("excludesamples",
                 argsMap, false, null, null));
         includesamples = Validate.getFile(Validate.stringArg("includesamples",
@@ -97,6 +100,7 @@ public final class HapIbdPar {
         min_markers = Validate.intArg("min-markers", argsMap, false, DEF_MIN_MARKERS, 1, IMAX);
         nthreads = Validate.intArg("nthreads", argsMap, false, DEF_NTHREADS, 1, IMAX);
         min_new_proxykey = Validate.intArg("min-new-proxykey", argsMap, false, DEF_MIN_NEW_PROXYKEY, 0, IMAX);
+        split = Validate.booleanArg("split", argsMap, false, DEF_SPLIT);
 
         Validate.confirmEmptyMap(argsMap);
     }
@@ -122,6 +126,7 @@ public final class HapIbdPar {
                 + "  gt=<VCF file with GT field>                         (required)" + nl
                 + "  map=<PLINK map file with cM units>                  (required)" + nl
                 + "  out=<output file prefix>                            (required)" + nl
+                + "  split-filename=<split filename>                     (optional)" + nl
                 + "  excludesamples=<excluded samples file>              (optional)" + nl
                 + "  includesamples=<included samples file>              (optional)" + nl + nl
 
@@ -133,15 +138,8 @@ public final class HapIbdPar {
                 + "  min-markers=<min markers in seed segment>           (default: " + DEF_MIN_MARKERS + ")" + nl
                 + "  min-mac=<minimum minor allele count filter>         (default: " + DEF_MIN_MAC + ")" + nl
                 + "  nthreads=<number of computational threads>          (default: all CPU cores)" + nl
-                + "  min-new-proxykey=<minimum new proxy key>            (default: " + DEF_MIN_NEW_PROXYKEY + ")";
-    }
-
-    private static ChromInterval parseChromInt(String chrom) {
-        ChromInterval ci = ChromInterval.parse(chrom);
-        if (chrom!=null && ci==null) {
-            throw new IllegalArgumentException("Invalid chrom parameter: " + chrom);
-        }
-        return ci;
+                + "  min-new-proxykey=<minimum new proxy key>            (default: " + DEF_MIN_NEW_PROXYKEY + ")" + nl
+                + "  split=<write output to individual files per sample> (default: " + DEF_SPLIT + ")";
     }
 
     // data input/output parameters
@@ -168,6 +166,14 @@ public final class HapIbdPar {
      */
     public String out() {
         return out;
+    }
+
+    /**
+     * Returns the splitFilename parameter.
+     * @return the splitFilename parameter
+     */
+    public String splitFilename() {
+        return splitFilename;
     }
 
     /**
@@ -257,5 +263,13 @@ public final class HapIbdPar {
      */
     public int min_new_proxykey() {
         return min_new_proxykey;
+    }
+
+    /**
+     * Returns the split parameter.
+     * @return the split parameter
+     */
+    public boolean split() {
+        return split;
     }
 }

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -483,7 +483,10 @@ public final class PbwtIbd implements Runnable {
         return writers.computeIfAbsent(proxyKey, key -> {
             try {
                 String dirPath = outputPrefix + "/" + key;
-                new File(dirPath).mkdirs();
+                File dir = new File(dirPath);
+                if (!dir.mkdirs() && !dir.isDirectory()) {
+                    Utilities.exit("ERROR: Failed to create directory " + dirPath);
+                }
                 String filename = dirPath + "/" + splitFilename + "." + type;
                 return new PrintWriter(new File(filename));
             }

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -467,7 +467,7 @@ public final class PbwtIbd implements Runnable {
         }
         int hap1ProxyKey = Integer.parseInt(ids[hap1>>1]);
         int hap2ProxyKey = Integer.parseInt(ids[hap2>>1]);
-        // Only write segments for new dogs x old dogs if min-new-proxykey is specified
+        // If min-new-proxykey is specified, only write segments for new dogs x old dogs 
         if (minNewProxykey > 0 && (hap1ProxyKey < minNewProxykey || hap2ProxyKey >= minNewProxykey)) {
             return;
         }

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -482,7 +482,9 @@ public final class PbwtIbd implements Runnable {
         Map<Integer, PrintWriter> writers = type.equals("ibd") ? ibdWriters : hbdWriters;
         return writers.computeIfAbsent(proxyKey, key -> {
             try {
-                String filename = outputPrefix + "/" + key + "/" + splitFilename + "." + type;
+                String dirPath = outputPrefix + "/" + key;
+                new File(dirPath).mkdirs();
+                String filename = dirPath + "/" + splitFilename + "." + type;
                 return new PrintWriter(new File(filename));
             }
             catch (IOException e) {

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -511,9 +511,11 @@ public final class PbwtIbd implements Runnable {
             PrintWriter splitWriter = getWriterForProxyKey(hap1ProxyKey, type);
             synchronized (splitWriter) {
                 printSegment(splitWriter, hap1ProxyKey, hap2ProxyKey, hap1, hap2, start, inclEnd);
+                splitWriter.println(); // flushes line to file
             }
         } else {
             printSegment(out, hap1ProxyKey, hap2ProxyKey, hap1, hap2, start, inclEnd);
+            out.print(Const.nl);
         }
 
     }
@@ -533,7 +535,6 @@ public final class PbwtIbd implements Runnable {
         out.print(pos[start]);
         out.print(Const.tab);
         out.print(pos[inclEnd]);
-        out.print(Const.nl);
     }
 
     public static void print3(double d, PrintWriter out) {

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -465,15 +465,17 @@ public final class PbwtIbd implements Runnable {
             hap1 = hap2;
             hap2 = tmp;
         }
-        // Only write segments with proxy keys >= minNewProxykey
-        if (Integer.parseInt(ids[hap1>>1]) < minNewProxykey) {
+        int hap1ProxyKey = Integer.parseInt(ids[hap1>>1]);
+        int hap2ProxyKey = Integer.parseInt(ids[hap2>>1]);
+        // Only write segments for new dogs x old dogs if min-new-proxykey is specified
+        if (minNewProxykey > 0 && (hap1ProxyKey < minNewProxykey || hap2ProxyKey >= minNewProxykey)) {
             return;
         }
-        out.print(ids[hap1>>1]);
+        out.print(hap1ProxyKey);
         out.print(Const.tab);
         out.print(HAP_TO_STRING[hap1 & 0b1]);
         out.print(Const.tab);
-        out.print(ids[hap2>>1]);
+        out.print(hap2ProxyKey);
         out.print(Const.tab);
         out.print(HAP_TO_STRING[hap2 & 0b1]);
         out.print(Const.tab);


### PR DESCRIPTION
Write output to individual files, one per proxy key. In benchmarking, increases runtime from 5 secs to 7 secs and eliminates need to split the single ibd output file, which was taking 10+ seconds.

Also, suggestion from Sam Vohr: Support two output modes: 1. new x old dogs 2. all x all dogs.

I have confirmed that this writes out the expected 6,000 files. One example:

```
$ head /tmp/tmpubabox4z/hapibd_output_2719340.ibd 
2719340	0	2429391	0	37	7699931	8792116
2719340	0	2433823	0	37	7699931	8792116
2719340	0	2434193	1	37	7699931	8792116
2719340	0	2435380	1	37	7699931	8792116
2719340	0	2429415	1	37	7699931	8837854
2719340	0	2431906	1	37	7699931	8837854
2719340	0	2434211	0	37	7699931	8837854
2719340	1	2436614	1	37	7858303	8910974
2719340	0	2431754	0	37	7950699	9020790
2719340	0	2433627	0	37	7950699	9020790
```