### PR TITLE
Ensure all match files are created when using split output

### DIFF
--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -180,6 +180,12 @@ public final class PbwtIbd implements Runnable {
     @Override
     public void run() {
         try {
+            if (split) {
+                for (String proxyKeyStr : this.ids) {
+                    getWriterForProxyKey(Integer.parseInt(proxyKeyStr), "ibd");
+                    getWriterForProxyKey(Integer.parseInt(proxyKeyStr), "hbd");
+                }
+            }
             int maxIbsStart = windowStart;
             for (int m=advancePbwtToFirstIbsEnd(); m<windowEnd; ++m) {
                 if ((m & 0b11)==0b11 && useSeedQ==false && FINISHED_CNT.get()>0) {


### PR DESCRIPTION
This change was required for experiments, but it is not clear if empty match files ever occur in production or if they would cause a problem. 