### PR TITLE
Split File Output Concurrency Fix

### DIFF
--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -40,7 +40,6 @@ import vcf.MarkerMap;
 import vcf.RefGT;
 import vcf.Samples;
 
-
 /**
  * <p>Instances of class {@code PbwtIbd} detect IBS segments in phased
  * genotype data.</p>

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -89,8 +89,6 @@ public final class PbwtIbd implements Runnable {
 
     private PrintWriter hbdOut = printWriter(hbdBaos);
     private PrintWriter ibdOut = printWriter(ibdBaos);
-    private final Map<Integer, PrintWriter> ibdWriters;
-    private final Map<Integer, PrintWriter> hbdWriters;
     private final String outputPrefix;
     private final String splitFilename;
     private final boolean split;
@@ -168,8 +166,6 @@ public final class PbwtIbd implements Runnable {
         this.splitFileWriterManager = splitFileWriterManager;
         this.outputPrefix = par.out();
         this.splitFilename = par.splitFilename();
-        this.ibdWriters = new ConcurrentHashMap<>();
-        this.hbdWriters = new ConcurrentHashMap<>();
 
         this.pbwt = new PbwtUpdater(nHaps);
         this.a = IntStream.range(0, nHaps).toArray();
@@ -472,25 +468,6 @@ public final class PbwtIbd implements Runnable {
                 Utilities.exit("ERROR: ", ex);
             }
         }
-    }
-
-    private PrintWriter getWriterForProxyKey(int proxyKey, String type) {
-        Map<Integer, PrintWriter> writers = type.equals("ibd") ? ibdWriters : hbdWriters;
-        return writers.computeIfAbsent(proxyKey, key -> {
-            try {
-                String dirPath = outputPrefix + "/" + key;
-                File dir = new File(dirPath);
-                if (!dir.mkdirs() && !dir.isDirectory()) {
-                    Utilities.exit("ERROR: Failed to create directory " + dirPath);
-                }
-                String filename = dirPath + "/" + splitFilename + "." + type;
-                return new PrintWriter(new File(filename));
-            }
-            catch (IOException e) {
-                Utilities.exit("ERROR creating " + type + " file for proxy key " + key + ": ", e);
-                return null; // This will never be reached due to Utilities.exit
-            }
-        });
     }
 
     private void writeSegment(int hap1, int hap2, int start, int inclEnd,

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -40,6 +40,7 @@ import vcf.MarkerMap;
 import vcf.RefGT;
 import vcf.Samples;
 
+
 /**
  * <p>Instances of class {@code PbwtIbd} detect IBS segments in phased
  * genotype data.</p>
@@ -329,11 +330,11 @@ public final class PbwtIbd implements Runnable {
             inclEnd = extendInclEnd(hap1, hap2, inclEnd);
             if ((genPos[inclEnd] - genPos[start])>=minOutput) {
                 if ((hap1>>1)==(hap2>>1)) {
-                    writeSegment(hap1, hap2, start, inclEnd, hbdOut, "hbd");
+                    writeSegment(hap1, hap2, start, inclEnd, hbdOut, SplitFileWriterManager.MatchType.HBD);
                     N_HBD_SEGS.incrementAndGet();
                 }
                 else {
-                    writeSegment(hap1, hap2, start, inclEnd, ibdOut, "ibd");
+                    writeSegment(hap1, hap2, start, inclEnd, ibdOut, SplitFileWriterManager.MatchType.IBD);
                     N_IBD_SEGS.incrementAndGet();
                 }
             }
@@ -471,7 +472,7 @@ public final class PbwtIbd implements Runnable {
     }
 
     private void writeSegment(int hap1, int hap2, int start, int inclEnd,
-            PrintWriter out, String type) {
+            PrintWriter out, SplitFileWriterManager.MatchType type) {
         // At Embark, the new dog, ie the higher proxy key, comes first
         if (Integer.parseInt(ids[hap1>>1]) < Integer.parseInt(ids[hap2>>1])) {
             int tmp = hap1;

--- a/src/hapibd/PbwtIbd.java
+++ b/src/hapibd/PbwtIbd.java
@@ -94,6 +94,8 @@ public final class PbwtIbd implements Runnable {
     private final String outputPrefix;
     private final String splitFilename;
     private final boolean split;
+    private SplitFileWriterManager splitFileWriterManager;
+
     private boolean useSeedQ = false;
     private final int nWindows;
     private final IntList seedList;
@@ -125,7 +127,8 @@ public final class PbwtIbd implements Runnable {
     public PbwtIbd(HapIbdPar par, RefGT gt, MarkerMap map,
             int windowStart, int windowEnd, int nWindows,
             BlockingQueue<int[]> seedQ,
-            SynchFileOutputStream hbdOS, SynchFileOutputStream ibdOS) {
+            SynchFileOutputStream hbdOS, SynchFileOutputStream ibdOS,
+            SplitFileWriterManager splitFileWriterManager) {
         if (gt.isPhased()==false) {
             throw new IllegalArgumentException("unphased data");
         }
@@ -162,6 +165,7 @@ public final class PbwtIbd implements Runnable {
         this.ibdOS = ibdOS;
         this.split = par.split();
 
+        this.splitFileWriterManager = splitFileWriterManager;
         this.outputPrefix = par.out();
         this.splitFilename = par.splitFilename();
         this.ibdWriters = new ConcurrentHashMap<>();
@@ -204,14 +208,6 @@ public final class PbwtIbd implements Runnable {
         }
         catch (Throwable t) {
             Utilities.exit(t);
-        }
-        finally {
-            for (PrintWriter writer : ibdWriters.values()) {
-                writer.close();
-            }
-            for (PrintWriter writer : hbdWriters.values()) {
-                writer.close();
-            }
         }
     }
 
@@ -513,7 +509,7 @@ public final class PbwtIbd implements Runnable {
         }
 
         if (split) {
-            PrintWriter splitWriter = getWriterForProxyKey(hap1ProxyKey, type);
+            PrintWriter splitWriter = splitFileWriterManager.getWriterForProxyKey(hap1ProxyKey, type);
             synchronized (splitWriter) {
                 printSegment(splitWriter, hap1ProxyKey, hap2ProxyKey, hap1, hap2, start, inclEnd);
                 splitWriter.println(); // flushes line to file

--- a/src/hapibd/PbwtIbdDriver.java
+++ b/src/hapibd/PbwtIbdDriver.java
@@ -91,7 +91,6 @@ public final class PbwtIbdDriver {
         } catch (IOException ex) {
             Utilities.exit(ex);
         }
-
         return nSamplesAndMarkers;
     }
 

--- a/src/hapibd/PbwtIbdDriver.java
+++ b/src/hapibd/PbwtIbdDriver.java
@@ -69,7 +69,8 @@ public final class PbwtIbdDriver {
         File ibdFile = new File(par.out() + ".ibd");
         try (SampleFileIt<RefGTRec> it = refIt(par);
                 SynchFileOutputStream hbdOS = new SynchFileOutputStream(hbdFile);
-                SynchFileOutputStream ibdOS = new SynchFileOutputStream(ibdFile)) {
+                SynchFileOutputStream ibdOS = new SynchFileOutputStream(ibdFile);
+                SplitFileWriterManager splitFileWriterManager = par.split() ? new SplitFileWriterManager(par) : null ){
             try {
                 nSamplesAndMarkers[0] = it.samples().nSamples();
                 List<RefGTRec> recList = new ArrayList<>(1<<14);
@@ -80,7 +81,7 @@ public final class PbwtIbdDriver {
                     if (recList.isEmpty()==false) {
                         RefGT gt = new RefGT(recList.toArray(new RefGTRec[0]));
                         MarkerMap map = MarkerMap.create(genMap, gt.markers());
-                        PbwtIbdDriver.detectIBD(par, gt, map, hbdOS, ibdOS);
+                        PbwtIbdDriver.detectIBD(par, gt, map, hbdOS, ibdOS, splitFileWriterManager);
                         nSamplesAndMarkers[1] += gt.nMarkers();
                     }
                 }
@@ -90,11 +91,13 @@ public final class PbwtIbdDriver {
         } catch (IOException ex) {
             Utilities.exit(ex);
         }
+
         return nSamplesAndMarkers;
     }
 
     private static void detectIBD(HapIbdPar par, RefGT gt, MarkerMap map,
-            SynchFileOutputStream hbdOS, SynchFileOutputStream ibdOS) {
+            SynchFileOutputStream hbdOS, SynchFileOutputStream ibdOS,
+            SplitFileWriterManager splitFileWriterManager) {
         float minSeed = par.min_seed();
         int minMarkers = par.min_markers();
         double[] genPos = map.genPos().toArray();
@@ -106,7 +109,7 @@ public final class PbwtIbdDriver {
         ExecutorService execService = Executors.newFixedThreadPool(starts.length);
         for (int j=0; j<starts.length; ++j) {
             PbwtIbd pbwtIbs = new PbwtIbd(par, gt, map, starts[j], ends[j],
-                    starts.length, seedQ, hbdOS, ibdOS);
+                    starts.length, seedQ, hbdOS, ibdOS, splitFileWriterManager);
             execService.submit(pbwtIbs);
         }
         MultiThreadUtils.shutdownExecService(execService);

--- a/src/hapibd/SplitFileWriterManager.java
+++ b/src/hapibd/SplitFileWriterManager.java
@@ -1,0 +1,52 @@
+package hapibd;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import blbutil.Utilities;
+
+public class SplitFileWriterManager implements AutoCloseable {
+    private final String outputPrefix;
+    private final String splitFilename;
+
+    private final Map<Integer, PrintWriter> ibdWriters;
+    private final Map<Integer, PrintWriter> hbdWriters;
+
+    public SplitFileWriterManager(HapIbdPar par) {
+        this.outputPrefix = par.out();
+        this.splitFilename = par.splitFilename();
+        this.ibdWriters = new ConcurrentHashMap<>();
+        this.hbdWriters = new ConcurrentHashMap<>();
+    }
+
+    public PrintWriter getWriterForProxyKey(int proxyKey, String type) {
+        Map<Integer, PrintWriter> writers = type.equals("ibd") ? ibdWriters : hbdWriters;
+        return writers.computeIfAbsent(proxyKey, key -> {
+            try {
+                String dirPath = outputPrefix + "/" + key;
+                File dir = new File(dirPath);
+                if (!dir.mkdirs() && !dir.isDirectory()) {
+                    Utilities.exit("ERROR: Failed to create directory " + dirPath);
+                }
+                String filename = dirPath + "/" + splitFilename + "." + type;
+                return new PrintWriter(new File(filename));
+            }
+            catch (IOException e) {
+                Utilities.exit("ERROR creating " + type + " file for proxy key " + key + ": ", e);
+                return null; // This will never be reached due to Utilities.exit
+            }
+        });
+    }
+
+    public synchronized void close() {
+        for (PrintWriter writer : ibdWriters.values()) {
+            writer.close();
+        }
+        for (PrintWriter writer : hbdWriters.values()) {
+            writer.close();
+        }
+    }
+}

--- a/src/hapibd/SplitFileWriterManager.java
+++ b/src/hapibd/SplitFileWriterManager.java
@@ -8,7 +8,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import blbutil.Utilities;
 
+
 public class SplitFileWriterManager implements AutoCloseable {
+
+    public static enum MatchType {HBD, IBD};
+
     private final String outputPrefix;
     private final String splitFilename;
 
@@ -22,8 +26,8 @@ public class SplitFileWriterManager implements AutoCloseable {
         this.hbdWriters = new ConcurrentHashMap<>();
     }
 
-    public PrintWriter getWriterForProxyKey(int proxyKey, String type) {
-        Map<Integer, PrintWriter> writers = type.equals("ibd") ? ibdWriters : hbdWriters;
+    public PrintWriter getWriterForProxyKey(int proxyKey, MatchType type) {
+        Map<Integer, PrintWriter> writers = type.equals(MatchType.IBD) ? ibdWriters : hbdWriters;
         return writers.computeIfAbsent(proxyKey, key -> {
             try {
                 String dirPath = outputPrefix + "/" + key;
@@ -31,7 +35,7 @@ public class SplitFileWriterManager implements AutoCloseable {
                 if (!dir.mkdirs() && !dir.isDirectory()) {
                     Utilities.exit("ERROR: Failed to create directory " + dirPath);
                 }
-                String filename = dirPath + "/" + splitFilename + "." + type;
+                String filename = dirPath + "/" + splitFilename + "." + type.toString().toLowerCase();
                 return new PrintWriter(new File(filename));
             }
             catch (IOException e) {


### PR DESCRIPTION
This PR fixes the split file output by introducing a class that manages the PrintWriters for each proxy key and file type ("IBD" and "HBD"). It includes some [suggested changes](https://embarkvet.atlassian.net/wiki/x/BAC3Vw) from a previous review. I [tested](https://embarkvet.atlassian.net/wiki/x/D4DkVw) this branch to confirm that the split files match the output from the single thread run and that using multiple threads decreases the wall runtime.

Some notes:
* Threads that call `getWriterForProxyKey` do not close PrintWriters, but there is nothing preventing them from doing so, which would cause problems for other threads trying to write to the same file.
* This PR does not include the temporary fix that ensures all possible output files are created. I don't know if it is needed beyond the ad hoc pipeline.
* The homozygous output files contain the ids and chromosome phase indexes for both haplotypes, which may not be necessary. 